### PR TITLE
fix: Enqueue flashSystemCluster reconcile req when secret gets changed

### DIFF
--- a/controllers/exporter.go
+++ b/controllers/exporter.go
@@ -51,7 +51,8 @@ const (
 	fsSecretPasswdKey   = "password"
 	fsSecretEndPointKey = "management_address"
 
-	CredentialHashAnnotation = "odf.ibm.com/credential-hash"
+	CredentialHashAnnotation  = "odf.ibm.com/credential-hash"
+	CredentialResourceVersion = "odf.ibm.com/credential-resource-version"
 
 	flashsystemPrometheusRuleFilepath = "/prometheus-rules/prometheus-flashsystem-rules.yaml"
 	// ruleName                          = "prometheus-flashsystem-rules"
@@ -165,8 +166,10 @@ func InitExporterDeployment(
 	if err != nil {
 		return nil, err
 	}
+
 	annotations := map[string]string{
-		CredentialHashAnnotation: secretDataHash,
+		CredentialHashAnnotation:  secretDataHash,
+		CredentialResourceVersion: secret.ResourceVersion,
 	}
 
 	return &appsv1.Deployment{

--- a/start-operator.sh
+++ b/start-operator.sh
@@ -18,5 +18,7 @@
 
 export WATCH_NAMESPACE=openshift-storage
 export EXPORTER_IMAGE=docker.io/ibmcom/ibm-storage-odf-block-driver:v0.0.22
+export TEST_FS_CR_FILEPATH="$(pwd)/config/samples/csi.ibm.com_v1_ibmblockcsi_cr.yaml"
+export TEST_FS_PROM_RULE_FILE="$(pwd)/rules/prometheus-flashsystem-rules.yaml"
 
 exec bin/manager


### PR DESCRIPTION
The problem is that after secret used by flashsystemcluster CR is changed, there is no reconciling action to update driver.

The fix is to add `EnqueueRequestsFromMapFunc` on secret resource to trigger reconciling on corresponding flashsystemcluster CR.