### PR TITLE
Add codespell, commitlint, golangci-lint actions, enable gosec linter in Makefile

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,20 @@
+name: codespell
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: codespell
+      uses: codespell-project/actions-codespell@master
+      with:
+        check_filenames: true
+        check_hidden: true

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,26 @@
+name: commitlint
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: run commitlint
+      uses: wagoid/commitlint-github-action@v3
+      with:
+        configFile: './.github/workflows/conf/commitlintrc.json'
+        helpURL: |
+          Some helpful links
+          Naming Conventions -> https://commitlint.js.org/#/concepts-commit-conventions
+          Rules -> https://commitlint.js.org/#/reference-rules
+          How to Write a Good Git Commit Message -> https://chris.beams.io/posts/git-commit

--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -1,0 +1,88 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "body-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "body-empty": [
+            1,
+            "never"
+        ],
+        "body-full-stop": [
+            1,
+            "always",
+            "."
+        ],
+        "body-leading-blank": [
+            2,
+            "always"
+        ],
+        "body-max-line-length": [
+            2,
+            "always",
+            72
+        ],
+        "footer-leading-blank": [
+            2,
+            "always"
+        ],
+        "header-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "header-full-stop": [
+            2,
+            "never",
+            "."
+        ],
+        "header-max-length": [
+            2,
+            "always",
+            72
+        ],
+        "signed-off-by": [
+            2,
+            "always"
+        ],
+        "subject-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "subject-empty": [
+            2,
+            "never"
+        ],
+        "type-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "type-empty": [
+            2,
+            "never"
+        ],
+        "type-enum": [
+            2,
+            "always",
+            [
+                "action",
+                "api",
+                "bundle",
+                "ci",
+                "config",
+                "controllers",
+                "docs",
+                "fix",
+                "godeps",
+                "makefile",
+                "test"
+            ]
+        ]
+    }
+}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,39 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: latest
+
+        # Optional: working directory, useful for monorepos
+        # working-directory: somedir
+
+        # Optional: golangci-lint command line arguments.
+        # TODO: remove --skip-files once logic is implemented
+        args: -E gosec --timeout=6m --skip-files controllers/suite_test.go
+
+        # Optional: show only new issues if it's a pull request. The default value is `false`.
+        # only-new-issues: true
+
+        # Optional: if set to true then the action will use pre-installed Go.
+        # skip-go-installation: true
+
+        # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+        # skip-pkg-cache: true
+
+        # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+        # skip-build-cache: true

--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -22,10 +22,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: golangci-lint
-      run: |
-        make lint
-
     - name: check copyright
       run: |
         make check-copyright

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ deps:
 
 .PHONY: lint
 lint: deps
-	golangci-lint run --timeout=6m    # Run `make lint-fix` may help to fix lint issues.
+	golangci-lint run -E gosec --timeout=6m    # Run `make lint-fix` may help to fix lint issues.
 
 .PHONY: lint-fix
 lint-fix: deps	


### PR DESCRIPTION
action: add codespell and commitlint actions for precheck
makefile: enable gosec linter for golangci-lint

Please help to review, thanks.

Signed-off-by: Bo Liu <lbseraph@gmail.com>