### PR TITLE
bundle: update kube-rbac-proxy supported image version to 4.9 for GA

### DIFF
--- a/bundle/manifests/ibm-storage-odf-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-storage-odf-operator.clusterserviceversion.yaml
@@ -277,7 +277,7 @@ spec:
                       - --upstream=http://127.0.0.1:8080/
                       - --logtostderr=true
                       - --v=10
-                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.7
+                    image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9
                     name: kube-rbac-proxy
                     ports:
                       - containerPort: 8443


### PR DESCRIPTION
Signed-off-by: Bo Liu <lbseraph@gmail.com>