### PR TITLE
Add Prometheus rules for storageSystem and storageClasses

### DIFF
--- a/rules/prometheus-flashsystem-rules.yaml
+++ b/rules/prometheus-flashsystem-rules.yaml
@@ -8,113 +8,171 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: odf-common.rules
-    rules:
-    - expr: |
-        avg by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_health_status
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-    - expr: |
-        sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_capacity_usable_bytes{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_raw_capacity_total_bytes
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-    - expr: |
-        sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_raw_capacity_used_bytes
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-    - expr: |
-        sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_rd_iops{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_subsystem_wr_iops{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_iops_total_bytes
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-    - expr: |
-        sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_rd_bytes{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_subsystem_wr_bytes{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_throughput_total_bytes
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-    - expr: |
-        sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_latency_seconds{subsystem_name="flashsystem-subsystem-name-template"})
-      record: odf_system_latency_seconds
-      labels: 
-        subsystem_vendor: IBM
-        subsystem_type: FlashSystem
-  - name: flashsystem-common.rules
-    rules:
-    - alert: FlashsystemClusterErrorState
-      annotations:
-        description: Subsystem storage "{{$labels.subsystem_name}}" in error state.
-        message: Subsystem storage "{{$labels.subsystem_name}}" is in error state
-        severity_level: error
-        storage_type: ibm_flashsystem
-      expr: |
-        flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"} ==2
-      for: 1m
-      labels:
-        severity: critical
-    - alert: FlashsystemClusterWarningState
-      annotations:
-        description: Subsystem storage "{{$labels.subsystem_name}}" in warning state for more than 5m. 
-        message: Subsystem storage "{{$labels.subsystem_name}}" is in warning state
-        severity_level: warning
-        storage_type: ibm_flashsystem
-      expr: |
-        flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"} ==1
-      for: 5m
-      labels:
-        severity: warning
-    - alert: FlashsystemMgrIsAbsent
-      annotations:
-        description: Subsystem storage manager "{{$labels.service}}" has disappeared from Prometheus target discovery.Please check the pod  {{$labels.pod}} logs to find out the cause.
-        message: Storage subsystem "{{$labels.service}}" metrics collector services is not available.
-        severity_level: error
-        storage_type: ibm_flashsystem
-      expr: |
-        up{job="flashsystem-subsystem-name-template"} !=1
-      for: 5m
-      labels:
-        severity: critical
-  - name: flashsystem-pool-status-alert.rules
-    rules:
-    - alert: FlashsystemPoolWarningState
-      annotations:
-        description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" is in degraded status for more than 5m.
-        message: "Subsystem storage pool is in degraded state."
-        severity_level: warning
-        storage_type: ibm_flashsystem
-      expr: |
-        flashsystem_pool_health{subsystem_name="flashsystem-subsystem-name-template"} ==1
-      for: 5m
-      labels:
-        severity: warning
-    - alert: FlashsystemPoolErrorState
-      annotations:
-        description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" is offline.
-        message: "Subsystem storage pool is in offline state."
-        severity_level: error
-        storage_type: ibm_flashsystem
-      expr: |
-        flashsystem_pool_health{subsystem_name="flashsystem-subsystem-name-template"} ==2
-      for: 1m
-      labels:
-        severity: critical
-  - name: flashsystem-pool-utilization-alert.rules
-    rules:
-    - alert: FlashsystemPoolNearFull
-      annotations:
-        description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" capacity utilization has crossed warning threshold for more than 5m.
-        message: Subsystem storage pool is nearing full. Data deletion or pool expansion is required.
-        severity_level: warning
-        storage_type: ibm_flashsystem
-      expr: |
-        flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"}/(flashsystem_pool_capacity_usable_bytes + flashsystem_pool_capacity_used_bytes) > flashsystem_pool_capacity_warning_threshold/100
-      for: 5m
-      labels:
-        severity: warning
+    - name: odf-common.rules
+      rules:
+        - expr: |
+            avg by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_health_status
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_physical_total_capacity_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_raw_capacity_total_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_physical_used_capacity_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_raw_capacity_used_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_rd_iops{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_subsystem_wr_iops{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_iops_total_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_rd_bytes{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_subsystem_wr_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_throughput_total_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_subsystem_latency_seconds{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_latency_seconds
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_logical_capacity_usable_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_logical_capacity_usable_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_logical_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_logical_capacity_used_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_logical_capacity_usable_bytes{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_pool_logical_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_logical_capacity_total_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_capacity_usable_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_physical_capacity_usable_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_physical_capacity_used_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+        - expr: |
+            sum by (subsystem_name,namespace,subsystem_vendor,subsystem_type) (flashsystem_pool_capacity_usable_bytes{subsystem_name="flashsystem-subsystem-name-template"}+flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"})
+          record: odf_system_pool_physical_capacity_total_bytes
+          labels:
+            subsystem_vendor: IBM
+            subsystem_type: FlashSystem
+    - name: flashsystem-common.rules
+      rules:
+        - alert: FlashsystemClusterErrorState
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}" in error state.
+            message: 'Subsystem storage "{{$labels.subsystem_name}}" is in error state'
+            severity_level: error
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"} ==2
+          for: 1m
+          labels:
+            severity: critical
+        - alert: FlashsystemClusterWarningState
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}" in warning state for more than 5m.
+            message: 'Subsystem storage "{{$labels.subsystem_name}}" is in warning state'
+            severity_level: warning
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_subsystem_health{subsystem_name="flashsystem-subsystem-name-template"} ==1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: FlashsystemMgrIsAbsent
+          annotations:
+            description: Subsystem storage manager "{{$labels.service}}" has disappeared from Prometheus target discovery.Please check the pod  {{$labels.pod}} logs to find out the cause.
+            message: 'Storage subsystem "{{$labels.service}}" metrics collector services is not available.'
+            severity_level: error
+            storage_type: ibm_flashsystem
+          expr: |
+            up{job="flashsystem-subsystem-name-template"} !=1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: FlashSystemStoragePhysicalCapacityNearFull
+          annotations:
+            description: Subsystem storage system "{{$labels.subsystem_name}}" physical capacity utilization has crossed warning threshold for more than 5m.
+            message: 'Subsystem storage system "{{$labels.subsystem_name}}" physical capacity is nearing full. Data deletion or expansion is required.'
+            severity_level: warning
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_subsystem_physical_used_capacity_bytes{subsystem_name="flashsystem-subsystem-name-template"}/flashsystem_subsystem_physical_total_capacity_bytes > flashsystem_pool_capacity_warning_threshold/100
+          for: 5m
+          labels:
+            severity: warning
+    - name: flashsystem-pool-status-alert.rules
+      rules:
+        - alert: FlashsystemPoolWarningState
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" is in degraded status for more than 5m.
+            message: 'Subsystem storage pool "{{$labels.pool_name}}" is in degraded state.'
+            severity_level: warning
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_pool_health{subsystem_name="flashsystem-subsystem-name-template"} ==1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: FlashsystemPoolErrorState
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" is offline.
+            message: 'Subsystem storage pool "{{$labels.pool_name}}" is in offline state.'
+            severity_level: error
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_pool_health{subsystem_name="flashsystem-subsystem-name-template"} ==2
+          for: 1m
+          labels:
+            severity: critical
+    - name: flashsystem-pool-utilization-alert.rules
+      rules:
+        - alert: FlashSystemPoolPhysicalCapacityNearFull
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" physical capacity utilization has crossed warning threshold for more than 5m.
+            message: 'Subsystem storage "{{$labels.subsystem_name}}" on pool "{{$labels.pool_name}}" physical capacity is nearing full. Data deletion or pool expansion is required.'
+            severity_level: warning
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_pool_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"}/(flashsystem_pool_capacity_usable_bytes + flashsystem_pool_capacity_used_bytes) > flashsystem_pool_capacity_warning_threshold/100
+          for: 5m
+          labels:
+            severity: warning
+        - alert: FlashSystemPoolLogicalCapacityNearFull
+          annotations:
+            description: Subsystem storage "{{$labels.subsystem_name}}", pool "{{$labels.pool_name}}" logical capacity utilization has crossed warning threshold for more than 5m.
+            message: 'Subsystem storage "{{$labels.subsystem_name}}" on pool "{{$labels.pool_name}}" logical capacity is nearing full. Data deletion or pool expansion is required.'
+            severity_level: warning
+            storage_type: ibm_flashsystem
+          expr: |
+            flashsystem_pool_logical_capacity_used_bytes{subsystem_name="flashsystem-subsystem-name-template"}/(flashsystem_pool_logical_capacity_usable_bytes + flashsystem_pool_logical_capacity_used_bytes) > flashsystem_pool_capacity_warning_threshold/100
+          for: 5m
+          labels:
+            severity: warning


### PR DESCRIPTION
Fix physical capacity labels for StorageSystem.
Expose new label for storageClass logical / physical capacity.

Add alerts for pool logical / physical capacity crossing threshold.

Signed-off-by: 662962756 <bvered@il.ibm.com>